### PR TITLE
feat(sprints): adiciona FK 'projeto_id' referenciando 'id' da tabela 'Projetos'

### DIFF
--- a/app/controllers/api/v2/projetos_controller.rb
+++ b/app/controllers/api/v2/projetos_controller.rb
@@ -18,7 +18,7 @@ class Api::V2::ProjetosController < ApplicationController
     @projeto = Projeto.new(projeto_params)
 
     if @projeto.save
-      render json: @projeto, status: :created, location: @projeto
+      render json: @projeto, status: :created, location: api_v2_projeto_url(@projeto)
     else
       render json: @projeto.errors, status: :unprocessable_entity
     end

--- a/app/controllers/api/v2/sprints_controller.rb
+++ b/app/controllers/api/v2/sprints_controller.rb
@@ -23,7 +23,7 @@ class Api::V2::SprintsController < ApplicationController
     @sprint = Sprint.new(sprint_params)
 
     if @sprint.save
-      render json: @sprint, status: :created, location: @sprint
+      render json: @sprint, status: :created, location: api_v2_sprint_url(@sprint)
     else
       render json: @sprint.errors, status: :unprocessable_entity
     end
@@ -57,6 +57,6 @@ class Api::V2::SprintsController < ApplicationController
 
     # Only allow a list of trusted parameters through.
     def sprint_params
-      params.expect(sprint: [ :nome, :data_inicio, :data_fim ])
+      params.expect(sprint: [ :nome, :data_inicio, :data_fim, :projeto_id ])
     end
 end

--- a/app/models/sprint.rb
+++ b/app/models/sprint.rb
@@ -1,2 +1,3 @@
 class Sprint < ApplicationRecord
+  belongs_to :projeto
 end

--- a/app/serializers/sprint_serializer.rb
+++ b/app/serializers/sprint_serializer.rb
@@ -1,3 +1,3 @@
 class SprintSerializer < ActiveModel::Serializer
-  attributes :id, :nome, :data_inicio, :data_fim
+  attributes :id, :nome, :data_inicio, :data_fim, :projeto_id
 end

--- a/db/migrate/20250204154642_add_projeto_to_sprints.rb
+++ b/db/migrate/20250204154642_add_projeto_to_sprints.rb
@@ -1,0 +1,5 @@
+class AddProjetoToSprints < ActiveRecord::Migration[8.0]
+  def change
+    add_reference :sprints, :projeto, foreign_key: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_02_03_211817) do
+ActiveRecord::Schema[8.0].define(version: 2025_02_04_154642) do
   create_table "equipe_projetos", force: :cascade do |t|
     t.integer "equipe_id", null: false
     t.integer "projeto_id", null: false
@@ -41,6 +41,8 @@ ActiveRecord::Schema[8.0].define(version: 2025_02_03_211817) do
     t.datetime "data_fim"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer "projeto_id"
+    t.index ["projeto_id"], name: "index_sprints_on_projeto_id"
   end
 
   create_table "usuario_equipes", force: :cascade do |t|
@@ -65,6 +67,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_02_03_211817) do
 
   add_foreign_key "equipe_projetos", "equipes"
   add_foreign_key "equipe_projetos", "projetos"
+  add_foreign_key "sprints", "projetos"
   add_foreign_key "usuario_equipes", "equipes"
   add_foreign_key "usuario_equipes", "usuarios"
 end


### PR DESCRIPTION
Modifica a estrutura da tabela 'Sprints' para incluir a chave estrangeira 'projeto_id', garantindo a relação entre sprints e projetos. Define a relação como **muitos-para-um**, onde várias sprints podem estar associadas a um único projeto. Essa alteração melhora a integridade dos dados e facilita consultas relacionadas.