### PR TITLE
feat(projetos): permite consulta de projeto com suas sprints

### DIFF
--- a/app/controllers/api/v2/projetos_controller.rb
+++ b/app/controllers/api/v2/projetos_controller.rb
@@ -10,7 +10,22 @@ class Api::V2::ProjetosController < ApplicationController
 
   # GET /projetos/1
   def show
-    render json: @projeto
+    @projeto = Usuario.find(params[:id])
+    if @projeto
+      render json: @projeto
+    else
+      render json: @projeto.errors, status: :not_found
+    end
+  end
+
+  # GET /projetos/ps/1
+  def show_projeto_sprint_by_id # Consulta projeto pelo id e retorna o projeto com suas sprints
+    @projeto = Projeto.includes(:sprints).find(params[:id])
+    if @projeto
+      render json: { projeto: @projeto, sprints: @projeto.sprints }
+    else
+      render json: @projeto.errors, status: :not_found
+    end
   end
 
   # POST /projetos

--- a/app/models/projeto.rb
+++ b/app/models/projeto.rb
@@ -1,2 +1,3 @@
 class Projeto < ApplicationRecord
+  has_many :sprints
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,11 +1,12 @@
 Rails.application.routes.draw do
   namespace :api do
     namespace :v2 do
-      get "usuarios/nome/:nome", to: "usuarios#show_by_name" # Rota para buscar usuário pelo nome
       resources :equipe_projetos
       resources :projetos
+      get "projetos/ps/:id", to: "projetos#show_projeto_sprint_by_id" # Rota para buscar projeto  pelo 'id' e retorná-lo com suas sprints
       resources :usuario_equipes
       resources :usuarios
+      get "usuarios/nome/:nome", to: "usuarios#show_by_name" # Rota para buscar usuário pelo nome
       resources :equipes, :sprints
     end
   end


### PR DESCRIPTION
Modifica 'projetos_controller' para incluir uma consulta por 'id' que retorna as sprints associadas a um projeto específico. Essa alteração melhora a navegação entre projetos e sprints, facilitando a obtenção de dados relacionados.