### PR TITLE
feat(auth): adiciona endpoint de login com JWT e hash de senha v2.11.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -57,4 +57,8 @@ group :development, :test do
   gem "rdoc", "~> 6.11.0"
 
   gem "rack-cors"
+
+  gem "jwt"
+
+  gem "bcrypt"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -81,6 +81,7 @@ GEM
     autoprefixer-rails (10.4.19.0)
       execjs (~> 2)
     base64 (0.2.0)
+    bcrypt (3.1.20)
     bcrypt_pbkdf (1.1.1)
     benchmark (0.4.0)
     bigdecimal (3.1.9)
@@ -123,6 +124,8 @@ GEM
       reline (>= 0.4.2)
     json (2.9.1)
     jsonapi-renderer (0.2.2)
+    jwt (2.10.1)
+      base64
     kamal (2.4.0)
       activesupport (>= 7.0)
       base64 (~> 0.2)
@@ -321,10 +324,12 @@ PLATFORMS
 
 DEPENDENCIES
   active_model_serializers
+  bcrypt
   bootsnap
   bootstrap
   brakeman
   debug
+  jwt
   kamal
   puma (>= 5.0)
   rack-cors

--- a/app/controllers/api/v2/authentication_controller.rb
+++ b/app/controllers/api/v2/authentication_controller.rb
@@ -1,0 +1,13 @@
+class Api::V2::AuthenticationController < ApplicationController
+  skip_before_action :authenticate_request
+
+  def login
+    @usuario = Usuario.find_by_email(params[:email])
+    if @usuario&.authenticate(params[:password])
+      token = jwt_encode(id: @usuario.id)
+      render json: { token: token }, status: :ok
+    else
+      render json: { error: "unauthorized" }, status: :unauthorized
+    end
+  end
+end

--- a/app/controllers/api/v2/usuarios_controller.rb
+++ b/app/controllers/api/v2/usuarios_controller.rb
@@ -1,4 +1,5 @@
 class Api::V2::UsuariosController < ApplicationController
+  skip_before_action :authenticate_request, only: [ :create, :index ]
   before_action :set_usuario, only: %i[ show update destroy ]
 
   # GET /usuarios
@@ -65,6 +66,6 @@ class Api::V2::UsuariosController < ApplicationController
 
     # Only allow a list of trusted parameters through.
     def usuario_params
-      params.expect(usuario: [ :nome, :senha, :email, :user_git, :excluido ])
+      params.expect(usuario: [ :nome, :password, :email, :user_git, :excluido ])
     end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,2 +1,13 @@
 class ApplicationController < ActionController::API
+  include JsonWebToken
+
+  before_action :authenticate_request
+
+  private
+  def authenticate_request
+    header = request.headers["Authorization"]
+    header = header.split(" ").last if header
+    decoded = jwt_decode(header)
+    @current_user = Usuario.find(decoded[:id])
+  end
 end

--- a/app/controllers/concerns/json_web_token.rb
+++ b/app/controllers/concerns/json_web_token.rb
@@ -1,0 +1,16 @@
+require "jwt"
+
+module JsonWebToken
+  extend ActiveSupport::Concern
+  SECRET_KEY = Rails.application.secret_key_base
+
+  def jwt_encode(payload, exp = 7.day.from_now)
+    payload[:exp] = exp.to_i
+    JWT.encode(payload, SECRET_KEY)
+  end
+
+  def jwt_decode(token)
+    decoded = JWT.decode(token, SECRET_KEY)[0]
+    HashWithIndifferentAccess.new decoded
+  end
+end

--- a/app/models/usuario.rb
+++ b/app/models/usuario.rb
@@ -1,4 +1,12 @@
 class Usuario < ApplicationRecord
+  require "securerandom"
+
+  has_secure_password
+
+  validates :email, presence: true
+  validates :nome, presence: true, uniqueness: true
+  validates :password, presence: true
+
   has_many :usuario_equipes
   has_many :equipes, through: :usuario_equipes
 end

--- a/app/serializers/usuario_serializer.rb
+++ b/app/serializers/usuario_serializer.rb
@@ -1,3 +1,3 @@
 class UsuarioSerializer < ActiveModel::Serializer
-  attributes :id, :nome, :email, :senha, :user_git, :excluido
+  attributes :id, :nome, :email, :user_git, :excluido
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,6 +5,7 @@ Rails.application.routes.draw do
       resources :projetos
       get "projetos/ps/:id", to: "projetos#show_projeto_sprint_by_id" # Rota para buscar projeto  pelo 'id' e retorná-lo com suas sprints
       resources :usuario_equipes
+      post "auth/login", to: "authentication#login"
       resources :usuarios
       get "usuarios/nome/:nome", to: "usuarios#show_by_name" # Rota para buscar usuário pelo nome
       resources :equipes, :sprints

--- a/db/migrate/20250213190247_remove_senha_from_usuarios.rb
+++ b/db/migrate/20250213190247_remove_senha_from_usuarios.rb
@@ -1,0 +1,5 @@
+class RemoveSenhaFromUsuarios < ActiveRecord::Migration[8.0]
+  def change
+    remove_column :usuarios, :senha, :string
+  end
+end

--- a/db/migrate/20250213190304_add_password_digest_to_usuarios.rb
+++ b/db/migrate/20250213190304_add_password_digest_to_usuarios.rb
@@ -1,0 +1,5 @@
+class AddPasswordDigestToUsuarios < ActiveRecord::Migration[8.0]
+  def change
+    add_column :usuarios, :password_digest, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_02_04_154642) do
+ActiveRecord::Schema[8.0].define(version: 2025_02_13_190304) do
   create_table "equipe_projetos", force: :cascade do |t|
     t.integer "equipe_id", null: false
     t.integer "projeto_id", null: false
@@ -58,11 +58,11 @@ ActiveRecord::Schema[8.0].define(version: 2025_02_04_154642) do
   create_table "usuarios", force: :cascade do |t|
     t.string "user_git"
     t.string "email"
-    t.string "senha"
     t.string "nome"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.boolean "excluido", default: false, null: false
+    t.string "password_digest"
   end
 
   add_foreign_key "equipe_projetos", "equipes"

--- a/test/controllers/authentication_controller_test.rb
+++ b/test/controllers/authentication_controller_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class AuthenticationControllerTest < ActionDispatch::IntegrationTest
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
Cria um endpoint de login que gera um JWT para autenticação. A senha do usuário agora é armazenada de forma segura utilizando o método 'has_secure_password', garantindo a segurança das credenciais. O campo 'senha' passa para 'password'