### PR TITLE
fix(config): define e-mail como único e limpa restrições de host v2.13.0

### DIFF
--- a/app/models/usuario.rb
+++ b/app/models/usuario.rb
@@ -4,7 +4,7 @@ class Usuario < ApplicationRecord
 
   has_secure_password
 
-  validates :email, presence: true
+  validates :email, presence: true, uniqueness: true
   validates :nome, presence: true, uniqueness: true
 
   has_many :usuario_equipes

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -86,4 +86,6 @@ Rails.application.configure do
     open_timeout: 5,
     read_timeout: 5
   }
+
+  config.hosts.clear
 end


### PR DESCRIPTION
- Adiciona validação de unicidade ao campo de e-mail nos modelos apropriados
- Utiliza 'config.hosts.clear' para permitir requisições externas sem restrições de host em ambientes de desenvolvimento

Essas mudanças visam prevenir conflitos de dados duplicados e facilitar testes de front-end via outros domínios.