### PR TITLE
refactor: Remove campo 'data_criacao'

### DIFF
--- a/db/migrate/20250828020008_remove_data_criacao_from_projetos.rb
+++ b/db/migrate/20250828020008_remove_data_criacao_from_projetos.rb
@@ -1,0 +1,5 @@
+class RemoveDataCriacaoFromProjetos < ActiveRecord::Migration[8.0]
+  def change
+    remove_column :projetos, :data_criacao, :date
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_08_28_014522) do
+ActiveRecord::Schema[8.0].define(version: 2025_08_28_020008) do
   create_table "active_storage_attachments", force: :cascade do |t|
     t.string "name", null: false
     t.string "record_type", null: false
@@ -84,7 +84,6 @@ ActiveRecord::Schema[8.0].define(version: 2025_08_28_014522) do
   create_table "projetos", force: :cascade do |t|
     t.string "nome"
     t.text "descricao"
-    t.date "data_criacao"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end


### PR DESCRIPTION
Campo 'data_criacao' na tabela 'projetos' não é utilizada em nenhum momento