### PR TITLE
refactor: Remove campo 'data_criacao' e 'data_alteracao'

### DIFF
--- a/db/migrate/20250828022135_remove_data_alteracao_from_tasks.rb
+++ b/db/migrate/20250828022135_remove_data_alteracao_from_tasks.rb
@@ -1,0 +1,5 @@
+class RemoveDataAlteracaoFromTasks < ActiveRecord::Migration[8.0]
+  def change
+    remove_column :tasks, :data_alteracao, :datetime
+  end
+end

--- a/db/migrate/20250828024430_remove_data_criacao_from_tasks.rb
+++ b/db/migrate/20250828024430_remove_data_criacao_from_tasks.rb
@@ -1,0 +1,5 @@
+class RemoveDataCriacaoFromTasks < ActiveRecord::Migration[8.0]
+  def change
+    remove_column :tasks, :data_criacao, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_08_28_020008) do
+ActiveRecord::Schema[8.0].define(version: 2025_08_28_024430) do
   create_table "active_storage_attachments", force: :cascade do |t|
     t.string "name", null: false
     t.string "record_type", null: false
@@ -110,8 +110,6 @@ ActiveRecord::Schema[8.0].define(version: 2025_08_28_020008) do
   create_table "tasks", force: :cascade do |t|
     t.string "titulo"
     t.text "descricao"
-    t.datetime "data_criacao"
-    t.datetime "data_alteracao"
     t.integer "status", default: 0
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false


### PR DESCRIPTION
Campos 'data_criacao' e 'data_alteracao' na tabela 'tasks' não é utilizada em nenhum momento